### PR TITLE
Add keyboard-controlled display brightness via `&inc_bri` / `&dec_bri` behaviors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,4 +18,10 @@ if(CONFIG_SHIELD_PROSPECTOR_ADAPTER)
         zephyr_library_sources(src/events/split_central_status_changed.c)
         zephyr_library_sources(src/split/bluetooth/central_status_changed_observer.c)
 
+        if(CONFIG_PROSPECTOR_BRIGHTNESS_MANUAL)
+                target_sources(app PRIVATE src/behaviors/behavior_brightness.c)
+                target_include_directories(app PRIVATE
+                        ${ZEPHYR_CURRENT_MODULE_DIR}/boards/shields/prospector_adapter/include)
+        endif()
+
 endif()

--- a/Kconfig
+++ b/Kconfig
@@ -66,15 +66,32 @@ config PROSPECTOR_MODIFIER_OS_MAC
 
 endchoice
 
-config PROSPECTOR_USE_AMBIENT_LIGHT_SENSOR
-    bool "Use ambient light sensor for auto brightness"
-    default y
+choice PROSPECTOR_BRIGHTNESS_MODE
+    prompt "Display brightness mode"
+    default PROSPECTOR_BRIGHTNESS_AUTO
+
+config PROSPECTOR_BRIGHTNESS_AUTO
+    bool "Auto (ambient light sensor)"
+
+config PROSPECTOR_BRIGHTNESS_FIXED
+    bool "Fixed brightness"
+
+config PROSPECTOR_BRIGHTNESS_MANUAL
+    bool "Manual (keyboard-controlled)"
+
+endchoice
 
 config PROSPECTOR_FIXED_BRIGHTNESS
-    int "Fixed display brightness"
+    int "Initial display brightness (1-100)"
     default 50
     range 1 100
-    depends on !PROSPECTOR_USE_AMBIENT_LIGHT_SENSOR
+    depends on !PROSPECTOR_BRIGHTNESS_AUTO
+
+config PROSPECTOR_BRIGHTNESS_STEP
+    int "Brightness adjustment step size"
+    default 10
+    range 1 50
+    depends on PROSPECTOR_BRIGHTNESS_MANUAL
 
 config PROSPECTOR_LAYER_NAME_UPPERCASE
     bool "Display layer names in uppercase"

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This is a [ZMK module](https://zmk.dev/docs/features/modules) that provides cust
 - BLE profile and output indicator
 - Active modifier display
 - Caps word indicator
+- Keyboard-controlled display brightness
 
 ## Installation
 
@@ -95,7 +96,7 @@ keymap {
 
 To customize, add config options to your `.conf` file:
 ```ini
-CONFIG_PROSPECTOR_USE_AMBIENT_LIGHT_SENSOR=n
+CONFIG_PROSPECTOR_BRIGHTNESS_FIXED=y
 CONFIG_PROSPECTOR_FIXED_BRIGHTNESS=80
 ```
 
@@ -103,9 +104,33 @@ CONFIG_PROSPECTOR_FIXED_BRIGHTNESS=80
 | Name | Description | Default |
 | ---- | ----------- | ------- |
 | `CONFIG_PROSPECTOR_ROTATE_DISPLAY_180` | Rotate the display 180 degrees | n |
-| `CONFIG_PROSPECTOR_USE_AMBIENT_LIGHT_SENSOR` | Use ambient light sensor for auto brightness | y |
-| `CONFIG_PROSPECTOR_FIXED_BRIGHTNESS` | Fixed display brightness when not using ambient light sensor | 50 (1-100) |
 | `CONFIG_PROSPECTOR_LAYER_NAME_UPPERCASE` | Convert layer names to uppercase (Operator and Radii only) | y |
+
+### Brightness
+
+Display brightness has three mutually exclusive modes, selected via Kconfig:
+
+| Name | Description | Default |
+| ---- | ----------- | ------- |
+| `CONFIG_PROSPECTOR_BRIGHTNESS_AUTO` | Auto brightness using the ambient light sensor | y |
+| `CONFIG_PROSPECTOR_BRIGHTNESS_FIXED` | Fixed brightness set at compile time | n |
+| `CONFIG_PROSPECTOR_BRIGHTNESS_MANUAL` | Manual brightness controlled from the keyboard at runtime | n |
+| `CONFIG_PROSPECTOR_FIXED_BRIGHTNESS` | Initial brightness level (used by fixed and manual modes) | 50 (1-100) |
+| `CONFIG_PROSPECTOR_BRIGHTNESS_STEP` | Step size for manual brightness adjustment (manual mode only) | 10 (1-50) |
+
+To use manual brightness control, add to your `.conf`:
+```ini
+CONFIG_PROSPECTOR_BRIGHTNESS_MANUAL=y
+CONFIG_PROSPECTOR_FIXED_BRIGHTNESS=50
+CONFIG_PROSPECTOR_BRIGHTNESS_STEP=10
+```
+
+Then include the brightness behaviors in your keymap:
+```c
+#include <behaviors/brightness.dtsi>
+```
+
+Use `&inc_bri` and `&dec_bri` in any layer binding to increase and decrease brightness.
 
 ### Modifiers
 | Name | Description | Default |

--- a/boards/shields/prospector_adapter/Kconfig.defconfig
+++ b/boards/shields/prospector_adapter/Kconfig.defconfig
@@ -55,7 +55,7 @@ config PWM
 config LED
     default y
 
-config PROSPECTOR_USE_AMBIENT_LIGHT_SENSOR
+config PROSPECTOR_BRIGHTNESS_AUTO
     select SENSOR
     select APDS9960
 

--- a/boards/shields/prospector_adapter/include/brightness.h
+++ b/boards/shields/prospector_adapter/include/brightness.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <stdint.h>
+
+/** Adjust brightness by delta (positive = brighter, negative = dimmer).
+ *  Clamps result to [1, 100]. */
+void prospector_adjust_brightness(int delta);
+
+/** Get current brightness level (1-100). */
+uint8_t prospector_get_brightness(void);

--- a/boards/shields/prospector_adapter/prospector_adapter.overlay
+++ b/boards/shields/prospector_adapter/prospector_adapter.overlay
@@ -54,4 +54,15 @@
       mod-active-color = <0x38FFB3>;
       mod-inactive-color = <0xB0B0B0>;
    };
+
+   behaviors {
+      inc_bri: inc_bri {
+         compatible = "zmk,behavior-brightness-inc";
+         #binding-cells = <0>;
+      };
+      dec_bri: dec_bri {
+         compatible = "zmk,behavior-brightness-dec";
+         #binding-cells = <0>;
+      };
+   };
 };

--- a/boards/shields/prospector_adapter/prospector_adapter.overlay
+++ b/boards/shields/prospector_adapter/prospector_adapter.overlay
@@ -55,14 +55,4 @@
       mod-inactive-color = <0xB0B0B0>;
    };
 
-   behaviors {
-      inc_bri: inc_bri {
-         compatible = "zmk,behavior-brightness-inc";
-         #binding-cells = <0>;
-      };
-      dec_bri: dec_bri {
-         compatible = "zmk,behavior-brightness-dec";
-         #binding-cells = <0>;
-      };
-   };
 };

--- a/boards/shields/prospector_adapter/src/brightness.c
+++ b/boards/shields/prospector_adapter/src/brightness.c
@@ -11,7 +11,7 @@ LOG_MODULE_REGISTER(als, 4);
 static const struct device *pwm_leds_dev = DEVICE_DT_GET_ONE(pwm_leds);
 #define DISP_BL DT_NODE_CHILD_IDX(DT_NODELABEL(disp_bl))
 
-#ifdef CONFIG_PROSPECTOR_USE_AMBIENT_LIGHT_SENSOR
+#if defined(CONFIG_PROSPECTOR_BRIGHTNESS_AUTO)
 
 static uint8_t current_brightness = 100;
 
@@ -145,7 +145,32 @@ extern void als_thread(void *d0, void *d1, void *d2) {
 K_THREAD_DEFINE(als_tid, 1024, als_thread, NULL, NULL, NULL, K_LOWEST_APPLICATION_THREAD_PRIO, 0,
                 0);
 
-#else
+#elif defined(CONFIG_PROSPECTOR_BRIGHTNESS_MANUAL)
+
+#include <brightness.h>
+
+static uint8_t manual_brightness = CONFIG_PROSPECTOR_FIXED_BRIGHTNESS;
+
+void prospector_adjust_brightness(int delta) {
+    int new_val = (int)manual_brightness + delta;
+    if (new_val < 1) new_val = 1;
+    if (new_val > 100) new_val = 100;
+    manual_brightness = (uint8_t)new_val;
+    led_set_brightness(pwm_leds_dev, DISP_BL, manual_brightness);
+}
+
+uint8_t prospector_get_brightness(void) {
+    return manual_brightness;
+}
+
+static int init_manual_brightness(void) {
+    led_set_brightness(pwm_leds_dev, DISP_BL, CONFIG_PROSPECTOR_FIXED_BRIGHTNESS);
+    return 0;
+}
+
+SYS_INIT(init_manual_brightness, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
+
+#else /* CONFIG_PROSPECTOR_BRIGHTNESS_FIXED */
 
 static int init_fixed_brightness(void) {
     led_set_brightness(pwm_leds_dev, DISP_BL, CONFIG_PROSPECTOR_FIXED_BRIGHTNESS);

--- a/dts/behaviors/brightness.dtsi
+++ b/dts/behaviors/brightness.dtsi
@@ -1,0 +1,12 @@
+/ {
+    behaviors {
+        inc_bri: inc_bri {
+            compatible = "zmk,behavior-brightness-inc";
+            #binding-cells = <0>;
+        };
+        dec_bri: dec_bri {
+            compatible = "zmk,behavior-brightness-dec";
+            #binding-cells = <0>;
+        };
+    };
+};

--- a/dts/bindings/behaviors/zmk,behavior-brightness-dec.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-brightness-dec.yaml
@@ -1,0 +1,5 @@
+description: Decrease display brightness
+
+compatible: "zmk,behavior-brightness-dec"
+
+include: zero_param.yaml

--- a/dts/bindings/behaviors/zmk,behavior-brightness-inc.yaml
+++ b/dts/bindings/behaviors/zmk,behavior-brightness-inc.yaml
@@ -1,0 +1,5 @@
+description: Increase display brightness
+
+compatible: "zmk,behavior-brightness-inc"
+
+include: zero_param.yaml

--- a/src/behaviors/behavior_brightness.c
+++ b/src/behaviors/behavior_brightness.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2024 The ZMK Contributors
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+#include <zephyr/device.h>
+#include <drivers/behavior.h>
+#include <zephyr/logging/log.h>
+#include <zmk/behavior.h>
+
+#include <brightness.h>
+
+LOG_MODULE_DECLARE(zmk, CONFIG_ZMK_LOG_LEVEL);
+
+/* ── Brightness Increment ─────────────────────────────────────────── */
+
+#define DT_DRV_COMPAT zmk_behavior_brightness_inc
+
+#if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
+
+static int on_brightness_inc_pressed(struct zmk_behavior_binding *binding,
+                                     struct zmk_behavior_binding_event event) {
+    prospector_adjust_brightness(CONFIG_PROSPECTOR_BRIGHTNESS_STEP);
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static int on_brightness_inc_released(struct zmk_behavior_binding *binding,
+                                      struct zmk_behavior_binding_event event) {
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static const struct behavior_driver_api brightness_inc_driver_api = {
+    .binding_pressed = on_brightness_inc_pressed,
+    .binding_released = on_brightness_inc_released,
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+    .get_parameter_metadata = zmk_behavior_get_empty_param_metadata,
+#endif
+};
+
+static int behavior_brightness_inc_init(const struct device *dev) { return 0; }
+
+#define BRI_INC_INST(n)                                                                            \
+    BEHAVIOR_DT_INST_DEFINE(n, behavior_brightness_inc_init, NULL, NULL, NULL, POST_KERNEL,        \
+                            CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &brightness_inc_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(BRI_INC_INST)
+
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(zmk_behavior_brightness_inc) */
+
+/* ── Brightness Decrement ─────────────────────────────────────────── */
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT zmk_behavior_brightness_dec
+
+#if DT_HAS_COMPAT_STATUS_OKAY(DT_DRV_COMPAT)
+
+static int on_brightness_dec_pressed(struct zmk_behavior_binding *binding,
+                                     struct zmk_behavior_binding_event event) {
+    prospector_adjust_brightness(-CONFIG_PROSPECTOR_BRIGHTNESS_STEP);
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static int on_brightness_dec_released(struct zmk_behavior_binding *binding,
+                                      struct zmk_behavior_binding_event event) {
+    return ZMK_BEHAVIOR_OPAQUE;
+}
+
+static const struct behavior_driver_api brightness_dec_driver_api = {
+    .binding_pressed = on_brightness_dec_pressed,
+    .binding_released = on_brightness_dec_released,
+#if IS_ENABLED(CONFIG_ZMK_BEHAVIOR_METADATA)
+    .get_parameter_metadata = zmk_behavior_get_empty_param_metadata,
+#endif
+};
+
+static int behavior_brightness_dec_init(const struct device *dev) { return 0; }
+
+#define BRI_DEC_INST(n)                                                                            \
+    BEHAVIOR_DT_INST_DEFINE(n, behavior_brightness_dec_init, NULL, NULL, NULL, POST_KERNEL,        \
+                            CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, &brightness_dec_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(BRI_DEC_INST)
+
+#endif /* DT_HAS_COMPAT_STATUS_OKAY(zmk_behavior_brightness_dec) */


### PR DESCRIPTION
# Feature description
Adds a manual brightness mode for the Prospector dongle display, allowing runtime backlight adjustment from the keyboard. I wanted to have this ability because many people choose to build Prospector dongle without an Ambient Light Sensor (incl. me), and being locked into having a fixed brightness is not the most elegant solution.

## Things changed:
  - New three-way Kconfig choice (`PROSPECTOR_BRIGHTNESS_AUTO` / `PROSPECTOR_BRIGHTNESS_FIXED` / `PROSPECTOR_BRIGHTNESS_MANUAL`) replaces the old
  `PROSPECTOR_USE_AMBIENT_LIGHT_SENSOR` bool
  - Two new zero-param ZMK behaviors: `&inc_bri` and `&dec_bri`
  - Step size configurable via `CONFIG_PROSPECTOR_BRIGHTNESS_STEP` (default 10)
  - Initial brightness set from `CONFIG_PROSPECTOR_FIXED_BRIGHTNESS`, no persistence across reboots (to avoid the chance that screen brightness was set to too low from the last manual setting)
  - Behavior DTS nodes in `dts/behaviors/brightness.dtsi` for inclusion in keymaps (ensures both dongle and peripheral builds resolve the node labels)

# Breaking changes
`CONFIG_PROSPECTOR_USE_AMBIENT_LIGHT_SENSOR` is removed. Use `CONFIG_PROSPECTOR_BRIGHTNESS_AUTO=y` instead.

# Testing
Tested on real hardware with this keyboard config:
  - [Changes to config](https://github.com/AbeerVaishnav13/zmk-config-delta-omega/blob/4c6b8685dbb2ce85549f029082d60772982cfb2e/config/delta_omega.conf#L7)
  - [Adding custom behaviors to keymap file](https://github.com/AbeerVaishnav13/zmk-config-delta-omega/blob/4c6b8685dbb2ce85549f029082d60772982cfb2e/config/delta_omega.keymap#L313)

# Test plan
  - Manual mode: `&inc_bri` / `&dec_bri` adjust backlight in real time
  - Fixed mode: brightness stays at configured value
  - Peripheral builds succeed (node labels resolved via dtsi include)