### PR TITLE
Feat/add bh1750

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,9 +103,11 @@ CONFIG_PROSPECTOR_FIXED_BRIGHTNESS=80
 | Name | Description | Default |
 | ---- | ----------- | ------- |
 | `CONFIG_PROSPECTOR_ROTATE_DISPLAY_180` | Rotate the display 180 degrees | n |
-| `CONFIG_PROSPECTOR_USE_AMBIENT_LIGHT_SENSOR` | Use ambient light sensor for auto brightness | y |
-| `CONFIG_PROSPECTOR_FIXED_BRIGHTNESS` | Fixed display brightness when not using ambient light sensor | 50 (1-100) |
 | `CONFIG_PROSPECTOR_LAYER_NAME_UPPERCASE` | Convert layer names to uppercase (Operator and Radii only) | y |
+| `CONFIG_PROSPECTOR_USE_AMBIENT_LIGHT_SENSOR` | Use ambient light sensor for auto brightness | y |
+| `CONFIG_PROSPECTOR_USE_APDS9960`    | Select APDS9960 as the ambient light sensor type(default)  | y    |
+| `CONFIG_PROSPECTOR_USE_BH1750`   | Select BH1750 as the ambient light sensor type    | n |
+| `CONFIG_PROSPECTOR_FIXED_BRIGHTNESS` | Fixed display brightness when not using ambient light sensor | 50 (1-100) |
 
 ### Modifiers
 | Name | Description | Default |

--- a/boards/shields/prospector_adapter/Kconfig.defconfig
+++ b/boards/shields/prospector_adapter/Kconfig.defconfig
@@ -62,19 +62,21 @@ config PROSPECTOR_USE_AMBIENT_LIGHT_SENSOR
 
 if PROSPECTOR_USE_AMBIENT_LIGHT_SENSOR
 
-choice PROSPECTOR_AMBIENT_LIGHT_SENSOR_TYPE
-	prompt "Ambient Light Sensor Type"
-	default PROSPECTOR_USE_APDS9960
-
 config PROSPECTOR_USE_APDS9960
 	bool "APDS9960 Sensor"
+	default y
+	depends on !PROSPECTOR_USE_BH1750
 	select APDS9960
+	help
+	  Use APDS9960. This option is disabled if BH1750 is selected.
 
 config PROSPECTOR_USE_BH1750
 	bool "BH1750 Sensor"
+	default n
+	depends on !PROSPECTOR_USE_APDS9960
 	select BH1750
-
-endchoice
+	help
+	  Use BH1750. This option is disabled if APDS9960 is selected.
 
 endif
 

--- a/boards/shields/prospector_adapter/Kconfig.defconfig
+++ b/boards/shields/prospector_adapter/Kconfig.defconfig
@@ -56,7 +56,26 @@ config LED
     default y
 
 config PROSPECTOR_USE_AMBIENT_LIGHT_SENSOR
-    select SENSOR
-    select APDS9960
+    bool "Enable Ambient Light Sensor"
+	default y
+	select SENSOR
+
+if PROSPECTOR_USE_AMBIENT_LIGHT_SENSOR
+
+choice PROSPECTOR_AMBIENT_LIGHT_SENSOR_TYPE
+	prompt "Ambient Light Sensor Type"
+	default PROSPECTOR_USE_APDS9960
+
+config PROSPECTOR_USE_APDS9960
+	bool "APDS9960 Sensor"
+	select APDS9960
+
+config PROSPECTOR_USE_BH1750
+	bool "BH1750 Sensor"
+	select BH1750
+
+endchoice
+
+endif
 
 endif

--- a/boards/shields/prospector_adapter/src/brightness.c
+++ b/boards/shields/prospector_adapter/src/brightness.c
@@ -85,10 +85,23 @@ extern void als_thread(void *d0, void *d1, void *d2) {
     struct sensor_value intensity;
     uint8_t mapped_brightness;
 
-    dev = DEVICE_DT_GET_ONE(avago_apds9960);
-    if (!device_is_ready(dev)) {
-        printk("sensor: device not ready.\n");
+    #if IS_ENABLED(CONFIG_PROSPECTOR_USE_BH1750)
+        dev = DEVICE_DT_GET_ONE(rohm_bh1750);
+    #elif IS_ENABLED(CONFIG_PROSPECTOR_USE_APDS9960)
+        dev = DEVICE_DT_GET_ONE(avago_apds9960);
+    #else
+        dev = NULL;
+        printk("sensor: No ambient light sensor configured.\n");
+    #endif
+
+    if (dev != NULL) {
+        if (!device_is_ready(dev)) {
+            printk("sensor: device not ready.\n");
+        } else {
+            printk("sensor: device %s is ready.\n", dev->name);
+        }
     }
+
 
     // led_set_brightness(pwm_leds_dev, DISP_BL, 100);
 


### PR DESCRIPTION
## Description
- Added support for the BH1750 ambient light sensor as an alternative to the APDS9960.
- Updated the Kconfig to allow selecting between the two sensors.
- Updated the README with the new configuration options.